### PR TITLE
endpoint default url and status

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Receive current Status of Overpass API endpoint.
 Overpass.status()
 ```
 
-The returned EndpointStatus struct provides the following fields:
+The returned Status struct provides the following fields:
 - `connection_id::String`
 - `server_time::DateTime`
 - `endpoint::Union{Nothing, String}`

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Receive current Status of Overpass API endpoint.
 Overpass.status()
 ```
 
-The returned OverpassStatus struct provides the following fields:
+The returned EndpointStatus struct provides the following fields:
 - `connection_id::String`
 - `server_time::DateTime`
 - `endpoint::Union{Nothing, String}`

--- a/src/Overpass.jl
+++ b/src/Overpass.jl
@@ -9,7 +9,7 @@ export query, set_endpoint, status, turbo_url
 # TYPES
 Bbox = Union{Nothing, NTuple{4, Number}}
 Center = Union{Nothing, NTuple{2, Number}}
-struct EndpointStatus
+struct Status
     connection_id::String
     server_time::DateTime
     endpoint::Union{Nothing, String}
@@ -89,11 +89,11 @@ function set_endpoint(endpoint::Union{Nothing, String} = nothing)::Bool
 end
 
 """
-    status()::EndpointStatus
+    status()::Status
 
 Receive current Status of Overpass API.
 
-EndpointStatus provides the following fields:
+Status provides the following fields:
 - connection_id::String
 - server_time::DateTime
 - endpoint::Union{Nothing, String}
@@ -102,7 +102,7 @@ EndpointStatus provides the following fields:
 
 See also [`set_endpoint`](@ref) to change Overpass API endpoint.
 """
-function status()::EndpointStatus
+function status()::Status
     url = @load_preference("endpoint", DEFAULT_ENDPOINT) * "status"
 
     response = HTTP.get(url)
@@ -119,7 +119,7 @@ function status()::EndpointStatus
 
     @debug "Status regex matches" matches
 
-    status = EndpointStatus(
+    status = Status(
         matches[:connection_id],
         DateTime(matches[:server_time], "yyyy-mm-ddTHH:MM:SSZ"),
         matches[:endpoint],

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,7 +54,7 @@ configure!(;
         @testset "default endpoint" begin
             status = playback(() -> Overpass.status(), "op-status")
 
-            @test status isa Overpass.OverpassStatus
+            @test status isa Overpass.EndpointStatus
             @test status.connection_id == "3158479246"
             @test status.server_time == DateTime("2024-11-11T23:37:10")
             @test status.endpoint == "lambert.openstreetmap.de/"
@@ -66,7 +66,7 @@ configure!(;
             Overpass.set_endpoint("https://maps.mail.ru/osm/tools/overpass/api/")
             status = playback(() -> Overpass.status(), "op-status-ru")
 
-            @test status isa Overpass.OverpassStatus
+            @test status isa Overpass.EndpointStatus
             @test status.connection_id == "1293416468"
             @test status.server_time == DateTime("2024-11-11T23:56:34")
             @test isnothing(status.endpoint)
@@ -80,7 +80,7 @@ configure!(;
             Overpass.set_endpoint("https://overpass.private.coffee/api/")
             status = playback(() -> Overpass.status(), "op-status-coffee")
 
-            @test status isa Overpass.OverpassStatus
+            @test status isa Overpass.EndpointStatus
             @test status.connection_id == "177472788"
             @test status.server_time == DateTime("2024-11-12T00:03:37")
             @test status.endpoint == "none"
@@ -94,7 +94,7 @@ configure!(;
             Overpass.set_endpoint("https://overpass.osm.jp/api/")
             status = playback(() -> Overpass.status(), "op-status-jp")
 
-            @test status isa Overpass.OverpassStatus
+            @test status isa Overpass.EndpointStatus
             @test status.connection_id == "1293416468"
             @test status.server_time == DateTime("2024-11-12T00:04:21")
             @test status.endpoint == "none"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,7 +54,7 @@ configure!(;
         @testset "default endpoint" begin
             status = playback(() -> Overpass.status(), "op-status")
 
-            @test status isa Overpass.EndpointStatus
+            @test status isa Overpass.Status
             @test status.connection_id == "3158479246"
             @test status.server_time == DateTime("2024-11-11T23:37:10")
             @test status.endpoint == "lambert.openstreetmap.de/"
@@ -66,7 +66,7 @@ configure!(;
             Overpass.set_endpoint("https://maps.mail.ru/osm/tools/overpass/api/")
             status = playback(() -> Overpass.status(), "op-status-ru")
 
-            @test status isa Overpass.EndpointStatus
+            @test status isa Overpass.Status
             @test status.connection_id == "1293416468"
             @test status.server_time == DateTime("2024-11-11T23:56:34")
             @test isnothing(status.endpoint)
@@ -80,7 +80,7 @@ configure!(;
             Overpass.set_endpoint("https://overpass.private.coffee/api/")
             status = playback(() -> Overpass.status(), "op-status-coffee")
 
-            @test status isa Overpass.EndpointStatus
+            @test status isa Overpass.Status
             @test status.connection_id == "177472788"
             @test status.server_time == DateTime("2024-11-12T00:03:37")
             @test status.endpoint == "none"
@@ -94,7 +94,7 @@ configure!(;
             Overpass.set_endpoint("https://overpass.osm.jp/api/")
             status = playback(() -> Overpass.status(), "op-status-jp")
 
-            @test status isa Overpass.EndpointStatus
+            @test status isa Overpass.Status
             @test status.connection_id == "1293416468"
             @test status.server_time == DateTime("2024-11-12T00:04:21")
             @test status.endpoint == "none"


### PR DESCRIPTION
- renamed struct `OverpassStatus` into `EndpointStatus`
- moved struct to #TYPES in line 12
- made hard coded URLs explicit